### PR TITLE
fix(input): use correct readonly attribute

### DIFF
--- a/cosmoz-input.js
+++ b/cosmoz-input.js
@@ -123,14 +123,19 @@ const styles = `
 
 	observedAttributes = [
 		'type',
+		'readonly',
 		'disabled',
-		'read-only',
+		'invalid',
 		'no-label-float',
-		'always-float-label',
-		'invalid'
+		'always-float-label'
 	];
 
 customElements.define(
 	'cosmoz-input',
 	component(Input, { observedAttributes })
 );
+
+export {
+	Input,
+	observedAttributes
+};


### PR DESCRIPTION
Correct the readonly attribute and export `Input` and `observedAttributes`.