### PR TITLE
fix(input): maintain focus & selection on mousedown inside cosmoz-input

### DIFF
--- a/cosmoz-input.js
+++ b/cosmoz-input.js
@@ -3,7 +3,7 @@ import { live } from 'lit-html/directives/live';
 import { useImperativeApi } from '@neovici/cosmoz-utils/lib/hooks/use-imperative-api';
 import { notifyProperty } from '@neovici/cosmoz-utils/lib/hooks/use-notify-property';
 import {
-	component, useCallback
+	component, useCallback, useEffect
 } from 'haunted';
 
 const styles = `
@@ -98,7 +98,25 @@ const styles = `
 			onFocus = useCallback(e => notifyProperty(host, 'focused', e.type === 'focus'), []),
 			focus = useCallback(() => host.shadowRoot.querySelector('input')?.focus(), []);
 
-		useImperativeApi({ focus });
+		useImperativeApi({ focus }, [focus]);
+
+		useEffect(() => {
+			const root = host.shadowRoot,
+				onMouseDown = e => {
+					if (e.target.matches('input, label')) {
+						return;
+					}
+					host.matches(':focus-within') // if input focused
+						? e.preventDefault() // don't blur
+						: focus(); // focus input
+				};
+
+			root.addEventListener('mousedown', onMouseDown);
+			return () => {
+				root.removeEventListener('mousedown', onMouseDown);
+			};
+		}, [focus]);
+
 
 		return html`
 		<style>${ styles }</style>

--- a/test/cosmoz-input.test.js
+++ b/test/cosmoz-input.test.js
@@ -30,13 +30,29 @@ suite('cosmoz-input', () => {
 		assert.isTrue(focusSpy.calledOnce);
 	});
 
-	test('focus', async () => {
+	test('value', async () => {
 		const inputSpy = spy(),
 			el = await fixture(html`<cosmoz-input></cosmoz-input>`);
 		el.addEventListener('value-changed', inputSpy, { once: true });
 		assert.isFalse(inputSpy.calledOnce);
 		el.shadowRoot.querySelector('input').dispatchEvent(new Event('input', { bubbles: true }));
 		assert.isTrue(inputSpy.calledOnce);
+	});
+
+	test('mousedown', async () => {
+		const focusSpy = spy(),
+			el = await fixture(html`<cosmoz-input><div slot="suffix"></div></cosmoz-input>`);
+		el.addEventListener('focused-changed', focusSpy, { once: true });
+		assert.isFalse(focusSpy.calledOnce);
+
+		el.shadowRoot.querySelector('input').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+		assert.isFalse(focusSpy.calledOnce);
+
+		el.querySelector('div').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+		assert.isTrue(focusSpy.calledOnce);
+
+		el.querySelector('div').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+		assert.isTrue(focusSpy.calledOnce);
 	});
 });
 


### PR DESCRIPTION
On mousedown on parts of `cosmoz-input` that are not the `label` or `input`
element (e.g. slotted elements) maintain the focus or re-focus the input.