### PR TITLE
fix: revert parts input prefixing

### DIFF
--- a/__snapshots__/cosmoz-input.md
+++ b/__snapshots__/cosmoz-input.md
@@ -5,22 +5,22 @@
 ```html
 <div
   class="float"
-  part="input-float"
+  part="float"
 >
 </div>
 <div
   class="wrap"
-  part="input-wrap"
+  part="wrap"
 >
   <slot name="prefix">
   </slot>
   <div
     class="control"
-    part="input-control"
+    part="control"
   >
     <input
       id="input"
-      part="input-input"
+      part="input"
       placeholder=" "
       type="text"
     >
@@ -30,7 +30,7 @@
 </div>
 <div
   class="line"
-  part="input-line"
+  part="line"
 >
 </div>
 
@@ -41,28 +41,28 @@
 ```html
 <div
   class="float"
-  part="input-float"
+  part="float"
 >
 </div>
 <div
   class="wrap"
-  part="input-wrap"
+  part="wrap"
 >
   <slot name="prefix">
   </slot>
   <div
     class="control"
-    part="input-control"
+    part="control"
   >
     <input
       id="input"
-      part="input-input"
+      part="input"
       placeholder=" "
       type="text"
     >
     <label
       for="input"
-      part="input-label"
+      part="label"
     >
       Label
     </label>
@@ -72,7 +72,7 @@
 </div>
 <div
   class="line"
-  part="input-line"
+  part="line"
 >
 </div>
 
@@ -83,22 +83,22 @@
 ```html
 <div
   class="float"
-  part="input-float"
+  part="float"
 >
 </div>
 <div
   class="wrap"
-  part="input-wrap"
+  part="wrap"
 >
   <slot name="prefix">
   </slot>
   <div
     class="control"
-    part="input-control"
+    part="control"
   >
     <input
       id="input"
-      part="input-input"
+      part="input"
       placeholder=" "
       type="text"
     >
@@ -108,12 +108,12 @@
 </div>
 <div
   class="line"
-  part="input-line"
+  part="line"
 >
 </div>
 <div
   class="error"
-  part="input-error"
+  part="error"
 >
   Something is wrong!
 </div>

--- a/cosmoz-input.js
+++ b/cosmoz-input.js
@@ -145,22 +145,22 @@ const styles = `
 
 		return html`
 		<style>${ styles }</style>
-		<div class="float" part="input-float">&nbsp;</div>
-		<div class="wrap" part="input-wrap">
+		<div class="float" part="float">&nbsp;</div>
+		<div class="wrap" part="wrap">
 			<slot name="prefix"></slot>
-			<div class="control" part="input-control">
-				<input id="input" part="input-input"
+			<div class="control" part="control">
+				<input id="input" part="input"
 					type=${ type } placeholder=${ placeholder || ' ' } ?readonly=${ readonly }
 					?aria-disabled=${ disabled } ?disabled=${ disabled }
 					.value=${ live(value ?? '') } autocomplete=${ ifDefined(autocomplete) }
 					@input=${ onInput } @focus=${ onFocus } @blur=${ onFocus }
 				>
-				${ label ? html`<label for="input" part="input-label">${ label }</label>` : nothing }
+				${ label ? html`<label for="input" part="label">${ label }</label>` : nothing }
 			</div>
 			<slot name="suffix"></slot>
 		</div>
-		<div class="line" part="input-line"></div>
-		${ invalid && errorMessage ? html`<div class="error" part="input-error">${ errorMessage }</div>` : nothing }
+		<div class="line" part="line"></div>
+		${ invalid && errorMessage ? html`<div class="error" part="error">${ errorMessage }</div>` : nothing }
 	`;
 	},
 


### PR DESCRIPTION
It seems we can rename when we `exportparts` and this is not need