### PR TITLE
fix(cosmoz-input): don't focus on mousedown if defaultPrevented

### DIFF
--- a/use-input.js
+++ b/use-input.js
@@ -18,7 +18,7 @@ export const useInput = host => {
 
 		useEffect(() => {
 			const onMouseDown = e => {
-				if (e.target.matches('input, textarea, label')) {
+				if (e.defaultPrevented || e.target.matches('input, textarea, label')) {
 					return;
 				}
 				e.preventDefault(); // don't blur


### PR DESCRIPTION
Do not focus input on mousedown inside root if default is prevented.