### PR TITLE
feat: show label when input no width AB#8568

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -94,6 +94,10 @@ export const styles = css`
 		text-overflow: ellipsis;
 	}
 
+	:host([float-label-value-selected]) label {
+		width: auto;
+	}
+
 	:host([always-float-label]) label,
 	#input:not(:placeholder-shown) + label {
 		transform: translateY(calc(var(--label-scale) * -100%))


### PR DESCRIPTION
Fixes [AB#8568](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/8568)
Added style for showing label based on attribute when the width of the input is 0 or close to 0, for cosmoz-autocomplete purposes.