### PR TITLE
feat(render): add control slot

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage/
 dist/
+__snapshots__

--- a/src/render.ts
+++ b/src/render.ts
@@ -23,6 +23,7 @@ export const render = <T>(
 		<div class="wrap" part="wrap">
 			<slot name="prefix"></slot>
 			<div class="control" part="control">
+				<slot name="control"></slot>
 				${control}
 				${when(
 					label,

--- a/test/__snapshots__/cosmoz-input.test.snap.js
+++ b/test/__snapshots__/cosmoz-input.test.snap.js
@@ -1,0 +1,123 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["cosmoz-input render"] = 
+`<div
+  class="float"
+  part="float"
+>
+</div>
+<div
+  class="wrap"
+  part="wrap"
+>
+  <slot name="prefix">
+  </slot>
+  <div
+    class="control"
+    part="control"
+  >
+    <slot name="control">
+    </slot>
+    <input
+      id="input"
+      part="input"
+      placeholder=" "
+      type="text"
+    >
+  </div>
+  <slot name="suffix">
+  </slot>
+</div>
+<div
+  class="line"
+  part="line"
+>
+</div>
+`;
+/* end snapshot cosmoz-input render */
+
+snapshots["cosmoz-input render label and value"] = 
+`<div
+  class="float"
+  part="float"
+>
+</div>
+<div
+  class="wrap"
+  part="wrap"
+>
+  <slot name="prefix">
+  </slot>
+  <div
+    class="control"
+    part="control"
+  >
+    <slot name="control">
+    </slot>
+    <input
+      id="input"
+      part="input"
+      placeholder=" "
+      type="text"
+    >
+    <label
+      for="input"
+      part="label"
+    >
+      Label
+    </label>
+  </div>
+  <slot name="suffix">
+  </slot>
+</div>
+<div
+  class="line"
+  part="line"
+>
+</div>
+`;
+/* end snapshot cosmoz-input render label and value */
+
+snapshots["cosmoz-input render errorMessage"] = 
+`<div
+  class="float"
+  part="float"
+>
+</div>
+<div
+  class="wrap"
+  part="wrap"
+>
+  <slot name="prefix">
+  </slot>
+  <div
+    class="control"
+    part="control"
+  >
+    <slot name="control">
+    </slot>
+    <input
+      id="input"
+      part="input"
+      placeholder=" "
+      type="text"
+    >
+  </div>
+  <slot name="suffix">
+  </slot>
+</div>
+<div
+  class="line"
+  part="line"
+>
+</div>
+<div
+  class="error"
+  part="error"
+>
+  Something is wrong!
+</div>
+`;
+/* end snapshot cosmoz-input render errorMessage */
+

--- a/test/__snapshots__/cosmoz-textarea.test.snap.js
+++ b/test/__snapshots__/cosmoz-textarea.test.snap.js
@@ -1,0 +1,40 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["cosmoz-textarea renders"] = 
+`<div
+  class="float"
+  part="float"
+>
+</div>
+<div
+  class="wrap"
+  part="wrap"
+>
+  <slot name="prefix">
+  </slot>
+  <div
+    class="control"
+    part="control"
+  >
+    <slot name="control">
+    </slot>
+    <textarea
+      id="input"
+      part="input"
+      placeholder=" "
+      rows="1"
+    >
+    </textarea>
+  </div>
+  <slot name="suffix">
+  </slot>
+</div>
+<div
+  class="line"
+  part="line"
+>
+</div>
+`;
+/* end snapshot cosmoz-textarea renders */
+

--- a/test/cosmoz-input.test.js
+++ b/test/cosmoz-input.test.js
@@ -5,42 +5,14 @@ import { spy } from 'sinon';
 describe('cosmoz-input', () => {
 	it('render', async () => {
 		const el = await fixture(html`<cosmoz-input></cosmoz-input>`);
-		expect(el).shadowDom.to.equal(
-			`
-			<div class="float" part="float"></div>
-			<div class="wrap" part="wrap">
-				<slot name="prefix"> </slot>
-				<div class="control" part="control">
-					<input id="input" part="input" placeholder=" " type="text" />
-				</div>
-				<slot name="suffix"></slot>
-			</div>
-			<div class="line" part="line"></div>
-		`,
-			{ ignoreAttributes: ['style'] }
-		);
+		await expect(el).shadowDom.to.equalSnapshot({ ignoreAttributes: ['style'] });
 	});
 
 	it('render label and value', async () => {
 		const el = await fixture(
 			html`<cosmoz-input .label=${'Label'} .value=${'value'}></cosmoz-input>`
 		);
-		expect(el).shadowDom.to.equal(
-			`
-			<div class="float" part="float"></div>
-			<div class="wrap" part="wrap">
-				<slot name="prefix"> </slot>
-				<div class="control" part="control">
-					<input id="input" part="input" placeholder=" " type="text" />
-					<label for="input" part="label">
-					Label
-					</label>
-				</div>
-				<slot name="suffix"> </slot>
-			</div>
-			<div class="line" part="line"></div>
-		`,
-			{ ignoreAttributes: ['style'] }
+		await expect(el).shadowDom.to.equalSnapshot({ ignoreAttributes: ['style'] }
 		);
 	});
 
@@ -52,23 +24,7 @@ describe('cosmoz-input', () => {
 				.value=${'wrong'}
 			></cosmoz-input>`
 		);
-		expect(el).shadowDom.to.equal(
-			`
-			<div class="float" part="float"></div>
-			<div class="wrap" part="wrap">
-				<slot name="prefix"> </slot>
-				<div class="control" part="control">
-					<input id="input" part="input" placeholder=" " type="text" />
-				</div>
-				<slot name="suffix"> </slot>
-			</div>
-			<div class="line" part="line"></div>
-			<div class="error" part="error">
-				Something is wrong!
-			</div>
-		`,
-			{ ignoreAttributes: ['style'] }
-		);
+		await expect(el).shadowDom.to.equalSnapshot({ ignoreAttributes: ['style'] });
 	});
 
 	it('focus', async () => {

--- a/test/cosmoz-textarea.test.js
+++ b/test/cosmoz-textarea.test.js
@@ -4,21 +4,15 @@ import { expect, html, fixture, nextFrame } from '@open-wc/testing';
 describe('cosmoz-textarea', () => {
 	it('renders', async () => {
 		const el = await fixture(html`<cosmoz-textarea />`);
-		expect(el).shadowDom.to.equal(`
-			<div class="float" part="float"></div>
-			<div class="wrap" part="wrap">
-				<slot name="prefix"> </slot>
-				<div class="control" part="control">
-					<textarea id="input" part="input" placeholder=" " rows="1" style="resize: none"></textarea>
-				</div>
-				<slot name="suffix"></slot>
-			</div>
-			<div class="line" part="line"></div>
-		`, { ignoreAttributes: ['style']});
+		await expect(el).shadowDom.to.equalSnapshot({
+			ignoreAttributes: ['style'],
+		});
 	});
 
 	it('auto grows', async () => {
-		const el = await fixture(html`<cosmoz-textarea .value=${ '1\n2\n3' } .maxRows=${ 2 } />`),
+		const el = await fixture(
+				html`<cosmoz-textarea .value=${'1\n2\n3'} .maxRows=${2} />`
+			),
 			input = el.shadowRoot.querySelector('#input');
 		await nextFrame();
 		await nextFrame();
@@ -26,5 +20,4 @@ describe('cosmoz-textarea', () => {
 		expect(height).to.be.above(40);
 		expect(height).to.be.below(61);
 	});
-
 });


### PR DESCRIPTION
Adds a `control` slot to place content next to the input.
