### PR TITLE
fix(float-label): label background color setting

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -118,7 +118,7 @@ export const styles = css`
 		--cosmoz-input-label-padding: 0 1px;
 		transform: translateY(calc(var(--label-scale) * -100%))
 			scale(var(--label-scale));
-		background-color: var(--cosmoz-input-floating-label-bg, transparent);
+		background-color: var(--cosmoz-input-floating-label-bg, var(--bg));
 	}
 	:host(:not(always-float-label):focus-within) #input::placeholder,
 	:host(:focus-within) label {

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -50,9 +50,9 @@ export const contour = () => html`
 			--cosmoz-input-label-width: auto;
 			--cosmoz-input-no-placeholder-label-bg: white;
 			--cosmoz-input-label-padding: 0;
-			--cosmoz-input-floating-label-bg: white;
 			--cosmoz-input-line-display: none;
 			--cosmoz-input-contour-size: 1px;
+			--cosmoz-input-background: white;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input!'}></cosmoz-input>


### PR DESCRIPTION
Feature [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - the value of the floating label background is set to be equal to the input background.
![image](https://github.com/Neovici/cosmoz-input/assets/122988480/814733fe-7f3a-4f57-9d04-86a21b74e7a4)
