### PR TITLE
feat(inputs): variable for input opacity

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -42,8 +42,8 @@ export const styles = css`
 		padding-top: var(--paper-input-container_-_padding-top, 8px);
 		padding-bottom: var(--paper-input-container_-_padding-bottom, 8px);
 		position: relative;
-		transition: 
-			transform 0.25s, 
+		transition:
+			transform 0.25s,
 			width 0.25s;
 		transform-origin: left top;
 		max-height: var(--cosmoz-input-max-height);
@@ -101,8 +101,8 @@ export const styles = css`
 		top: 0;
 		left: 0;
 		width: var(--cosmoz-input-label-width, 100%);
-		transition: 
-			transform 0.25s, 
+		transition:
+			transform 0.25s,
 			width 0.25s;
 		transform-origin: left top;
 		color: var(--color);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -42,8 +42,8 @@ export const styles = css`
 		padding-top: var(--paper-input-container_-_padding-top, 8px);
 		padding-bottom: var(--paper-input-container_-_padding-bottom, 8px);
 		position: relative;
-		transition:
-			transform 0.25s,
+		transition: 
+			transform 0.25s, 
 			width 0.25s;
 		transform-origin: left top;
 		max-height: var(--cosmoz-input-max-height);
@@ -67,6 +67,7 @@ export const styles = css`
 		align-items: center;
 		position: relative;
 		background: var(--bg);
+		opacity: var(--cosmoz-input-opacity);
 		border-radius: var(--cosmoz-input-border-radius);
 		box-shadow: 0 0 0 var(--contour-size) var(--contour-color);
 	}
@@ -100,8 +101,8 @@ export const styles = css`
 		top: 0;
 		left: 0;
 		width: var(--cosmoz-input-label-width, 100%);
-		transition:
-			transform 0.25s,
+		transition: 
+			transform 0.25s, 
 			width 0.25s;
 		transform-origin: left top;
 		color: var(--color);

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -53,6 +53,7 @@ export const contour = () => html`
 			--cosmoz-input-line-display: none;
 			--cosmoz-input-contour-size: 1px;
 			--cosmoz-input-background: white;
+			--cosmoz-input-opacity: 0.7;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input!'}></cosmoz-input>

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -45,6 +45,7 @@ export const color = () => html`
 export const contour = () => html`
 	<style>
 		cosmoz-input {
+			--cosmoz-input-color: #aeacac;
 			--cosmoz-input-border-radius: 4px;
 			--cosmoz-input-padding: 8px;
 			--cosmoz-input-label-width: auto;

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -53,7 +53,6 @@ export const contour = () => html`
 			--cosmoz-input-line-display: none;
 			--cosmoz-input-contour-size: 1px;
 			--cosmoz-input-background: white;
-			--cosmoz-input-opacity: 0.7;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input!'}></cosmoz-input>


### PR DESCRIPTION
Feature [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - styling tweaks. The opacity of the inputs is now settable from the outside and the "Required" error message is no longer shown
![image](https://github.com/Neovici/cosmoz-input/assets/122988480/3314ff92-5597-4b2c-85b6-d43792e79a2c)
