### PR TITLE
fix(inputs-float): display of float div linked to a var

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -35,10 +35,11 @@ export const styles = css`
 			--cosmoz-input-focused-color,
 			var(--primary-color, #3f51b5)
 		);
-		--float-display: var(--cosmoz-input-float-display, block)
+		--float-display: var(--cosmoz-input-float-display, block);
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
+		--margin-top-not-first: var(--cosmoz-input-margin-top-not-first, 0px);
 
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
@@ -52,7 +53,9 @@ export const styles = css`
 		line-height: var(--line-height);
 		font-family: var(--font-family);
 	}
-
+	:host:not(:first-child) {
+		margin-top: var(--margin-top-not-first);
+	}
 	:host([disabled]) {
 		opacity: var(--disabled-opacity);
 	}
@@ -60,7 +63,7 @@ export const styles = css`
 	.float {
 		line-height: calc(var(--line-height) * var(--label-scale));
 		background-color: var(--cosmoz-input-float-bg-color, none);
-		display: var(--float-display, block);
+		display: var(--float-display);
 	}
 
 	.wrap {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -39,7 +39,6 @@ export const styles = css`
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
-		--margin-top-not-first: var(--cosmoz-input-margin-top-not-first, 0px);
 
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
@@ -53,9 +52,7 @@ export const styles = css`
 		line-height: var(--line-height);
 		font-family: var(--font-family);
 	}
-	:host:not(:first-child) {
-		margin-top: var(--margin-top-not-first);
-	}
+
 	:host([disabled]) {
 		opacity: var(--disabled-opacity);
 	}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -35,6 +35,7 @@ export const styles = css`
 			--cosmoz-input-focused-color,
 			var(--primary-color, #3f51b5)
 		);
+		--float-display: var(--cosmoz-input-float-display, block)
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
@@ -59,6 +60,7 @@ export const styles = css`
 	.float {
 		line-height: calc(var(--line-height) * var(--label-scale));
 		background-color: var(--cosmoz-input-float-bg-color, none);
+		display: var(--float-display, block);
 	}
 
 	.wrap {

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -59,6 +59,10 @@ export const contour = () => html`
 			--cosmoz-input-line-display: none;
 			--cosmoz-input-contour-size: 1px;
 			--cosmoz-input-label-translate-y: 10px;
+			--cosmoz-input-float-display: none;
+		}
+		cosmoz-input:not(:first-child) {
+			margin-top: 10px;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input'}></cosmoz-input>

--- a/stories/cosmoz-textarea.stories.js
+++ b/stories/cosmoz-textarea.stories.js
@@ -32,6 +32,7 @@ const basic = () => html`
 				--cosmoz-input-line-display: none;
 				--cosmoz-input-contour-size: 1px;
 				--cosmoz-input-label-translate-y: 10px;
+				--cosmoz-input-float-display: none;
 			}
 		</style>
 		<cosmoz-textarea

--- a/stories/cosmoz-textarea.stories.js
+++ b/stories/cosmoz-textarea.stories.js
@@ -34,10 +34,24 @@ const basic = () => html`
 				--cosmoz-input-label-translate-y: 10px;
 				--cosmoz-input-float-display: none;
 			}
+			cosmoz-textarea:not(:first-child) {
+				margin-top: 10px;
+			}
 		</style>
 		<cosmoz-textarea
 			.label=${'Write your comment here'}
 			.value=${loremIpsum}
+		></cosmoz-textarea>
+		<cosmoz-textarea
+			invalid
+			.errorMessage=${'Something is rotten in the state of Denmark'}
+			.label=${'Write another comment here'}
+			.value=${loremIpsum.toUpperCase()}
+		></cosmoz-textarea>
+		<cosmoz-textarea
+			disabled
+			.label=${'Write another comment here'}
+			.value=${'You cannot type anything here!'}
 		></cosmoz-textarea>
 	`;
 export { basic, error, contour };


### PR DESCRIPTION
Fixes on [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - removing of whitespace between inputs via adding a var which allows to control the displaying of the `.float` element in inputs, so to allow its maintenance in the old design.
![image](https://github.com/Neovici/cosmoz-input/assets/122988480/9b89a720-1869-4e3d-a9d2-97dc630895b2)
