### PR TITLE
fix(label-duplication): identical placeholder and label cause a duplication glitch

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -4,5 +4,8 @@ interface Props {
 	placeholder?: string;
 }
 export const getPlaceholder = ({ placeholder, noLabelFloat, label }: Props) => {
+	if (placeholder === label) {
+		return ' ';
+	}
 	return (noLabelFloat ? label : undefined) || placeholder || ' ';
-}
+};

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -65,7 +65,12 @@ export const contour = () => html`
 			margin-top: 10px;
 		}
 	</style>
-	<cosmoz-input .label=${'Insert a text input'}></cosmoz-input>
+	<!--The following input contains a placeholder strictly equal to the label, 
+	for testing the anti-duplication condition set in util.ts-->
+	<cosmoz-input
+		.label=${'Insert a text input'}
+		.placeholder=${'Insert a text input'} 
+	></cosmoz-input>
 	<cosmoz-input
 		always-float-label
 		.label=${'This label always floats'}


### PR DESCRIPTION
Final fix for [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - input fields would show a label duplication glitch, which turned out when placeholder and label were equal. This new conditions prevents this double showing

Uploading Screenshare - 2024-03-26 2_35_59 PM.mp4…

