### PR TITLE
fix(wrap): padding var to be distinguished bewteen inside and outsie the input fieldq

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -64,7 +64,7 @@ export const styles = css`
 	}
 
 	.wrap {
-		padding: var(--cosmoz-input-padding, 0px);
+		padding: var(--cosmoz-input-wrap-padding, 0px);
 		display: flex;
 		align-items: center;
 		position: relative;

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -55,7 +55,7 @@ export const contour = () => html`
 		cosmoz-input {
 			--cosmoz-input-color: #aeacac;
 			--cosmoz-input-border-radius: 4px;
-			--cosmoz-input-padding: 12px;
+			--cosmoz-input-wrap-padding: 12px;
 			--cosmoz-input-line-display: none;
 			--cosmoz-input-contour-size: 1px;
 			--cosmoz-input-label-translate-y: 10px;

--- a/stories/cosmoz-textarea.stories.js
+++ b/stories/cosmoz-textarea.stories.js
@@ -28,7 +28,7 @@ const basic = () => html`
 			cosmoz-textarea {
 				--cosmoz-input-color: #aeacac;
 				--cosmoz-input-border-radius: 4px;
-				--cosmoz-input-padding: 12px;
+				--cosmoz-input-wrap-padding: 12px;
 				--cosmoz-input-line-display: none;
 				--cosmoz-input-contour-size: 1px;
 				--cosmoz-input-label-translate-y: 10px;


### PR DESCRIPTION
Fixes [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - having the same var for the padding inside and outside the input field caused a weird spacing issues. This fix allows the two paddings to be set separately.

https://neovici.slack.com/archives/C0APSNTPB/p1712591310543809?thread_ts=1711117281.147589&cid=C0APSNTPB

