### PR TITLE
fix(padding): supplementary control over padding for inputs

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -42,14 +42,6 @@ export const styles = css`
 
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
-		padding-top: var(
-			--cosmoz-input-padding-top,
-			var(--paper-input-container_-_padding-top, 8px)
-		);
-		padding-bottom: var(
-			--cosmoz-input-padding-bottom
-				var(--paper-input-container_-_padding-bottom, 8px)
-		);
 		position: relative;
 		transition: transform 0.25s, width 0.25s;
 		transform-origin: left top;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -42,8 +42,14 @@ export const styles = css`
 
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
-		padding-top: var(--paper-input-container_-_padding-top, 8px);
-		padding-bottom: var(--paper-input-container_-_padding-bottom, 8px);
+		padding-top: var(
+			--cosmoz-input-padding-top,
+			var(--paper-input-container_-_padding-top, 8px)
+		);
+		padding-bottom: var(
+			--cosmoz-input-padding-bottom
+				var(--paper-input-container_-_padding-bottom, 8px)
+		);
 		position: relative;
 		transition: transform 0.25s, width 0.25s;
 		transform-origin: left top;

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -60,9 +60,8 @@ export const contour = () => html`
 			--cosmoz-input-contour-size: 1px;
 			--cosmoz-input-label-translate-y: 10px;
 			--cosmoz-input-float-display: none;
-		}
-		cosmoz-input:not(:first-child) {
-			margin-top: 10px;
+			--cosmoz-input-padding-top: 10px;
+			--cosmoz-input-padding-bottom: 10px;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input'}></cosmoz-input>

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -60,8 +60,7 @@ export const contour = () => html`
 			--cosmoz-input-contour-size: 1px;
 			--cosmoz-input-label-translate-y: 10px;
 			--cosmoz-input-float-display: none;
-			--cosmoz-input-padding-top: 10px;
-			--cosmoz-input-padding-bottom: 10px;
+			--cosmoz-input-padding: 10px 8px;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input'}></cosmoz-input>

--- a/stories/cosmoz-textarea.stories.js
+++ b/stories/cosmoz-textarea.stories.js
@@ -33,6 +33,7 @@ const basic = () => html`
 				--cosmoz-input-contour-size: 1px;
 				--cosmoz-input-label-translate-y: 10px;
 				--cosmoz-input-float-display: none;
+				--cosmoz-input-padding: 10px 8px;
 			}
 			cosmoz-textarea:not(:first-child) {
 				margin-top: 10px;


### PR DESCRIPTION
[AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - padding controlling vars were overwriting the `--cosmoz-input-padding` var, so two new vars are added to allow separate control over this.