### PR TITLE
fix(slots): suffix and prefix slots needs to follow the same placing of the input content

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -40,7 +40,8 @@ export const styles = css`
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
 		display: block;
-		padding: var(--cosmoz-input-padding, 8px 0);
+		padding: var(--
+			cosmoz-input-padding, 8px 0);
 		position: relative;
 		transition: transform 0.25s, width 0.25s;
 		transform-origin: left top;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -40,8 +40,8 @@ export const styles = css`
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
 		display: block;
-		padding: var(--
-			cosmoz-input-padding, 8px 0);
+		
+		padding: var(--cosmoz-input-padding, 8px 0);
 		position: relative;
 		transition: transform 0.25s, width 0.25s;
 		transform-origin: left top;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -77,10 +77,6 @@ export const styles = css`
 		position: relative;
 	}
 
-	::slotted(*) {
-		padding: var(--slot-padding);
-	}
-
 	#input {
 		padding: 0;
 		margin: 0;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -39,7 +39,7 @@ export const styles = css`
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
-
+		--slot-padding: var(--cosmoz-input-slot-padding);
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
 		position: relative;
@@ -71,10 +71,17 @@ export const styles = css`
 		border-radius: var(--cosmoz-input-border-radius);
 		box-shadow: 0 0 0 var(--contour-size) var(--contour-color);
 	}
-
+	.wrap:has(#input:not(:placeholder-shown)) slot[name='suffix']::slotted(*),
+	.wrap:has(#input:not(:placeholder-shown)) slot[name='prefix']::slotted(*) {
+		transform: translateY(var(--label-translate-y));
+	}
 	.control {
 		flex: 1;
 		position: relative;
+	}
+
+	::slotted(*) {
+		padding: var(--slot-padding);
 	}
 
 	#input {
@@ -119,9 +126,17 @@ export const styles = css`
 			scale(var(--label-scale));
 		background-color: var(--cosmoz-input-floating-label-bg, var(--bg));
 	}
-
+	:host([always-float-label])::slotted(*),
+	#input:not(:placeholder-shown)::slotted(*) {
+		transform: translateY(var(--label-translate-y));
+	}
 	:host([always-float-label]) input,
 	#input:not(:placeholder-shown) {
+		transform: translateY(var(--label-translate-y));
+	}
+
+	:host([always-float-label]) slot[name='suffix']::slotted(*),
+	:host([always-float-label]) slot[name='prefix']::slotted(*) {
 		transform: translateY(var(--label-translate-y));
 	}
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -39,7 +39,7 @@ export const styles = css`
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
-		
+
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
 		position: relative;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -39,8 +39,8 @@ export const styles = css`
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
-		display: block;
 		
+		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
 		position: relative;
 		transition: transform 0.25s, width 0.25s;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -39,7 +39,6 @@ export const styles = css`
 		--contour-color: var(--line-color);
 		--contour-size: var(--cosmoz-input-contour-size);
 		--label-translate-y: var(--cosmoz-input-label-translate-y, 0%);
-		--slot-padding: var(--cosmoz-input-slot-padding);
 		display: block;
 		padding: var(--cosmoz-input-padding, 8px 0);
 		position: relative;
@@ -71,10 +70,7 @@ export const styles = css`
 		border-radius: var(--cosmoz-input-border-radius);
 		box-shadow: 0 0 0 var(--contour-size) var(--contour-color);
 	}
-	.wrap:has(#input:not(:placeholder-shown)) slot[name='suffix']::slotted(*),
-	.wrap:has(#input:not(:placeholder-shown)) slot[name='prefix']::slotted(*) {
-		transform: translateY(var(--label-translate-y));
-	}
+
 	.control {
 		flex: 1;
 		position: relative;
@@ -117,7 +113,10 @@ export const styles = css`
 		text-transform: var(--cosmoz-input-label-text-transform);
 		font-weight: var(--cosmoz-input-label-font-weight);
 	}
-
+	.wrap:has(#input:not(:placeholder-shown)) slot[name='suffix']::slotted(*),
+	.wrap:has(#input:not(:placeholder-shown)) slot[name='prefix']::slotted(*) {
+		transform: translateY(var(--label-translate-y));
+	}
 	:host([always-float-label]) label,
 	#input:not(:placeholder-shown) + label {
 		transform: translateY(
@@ -126,10 +125,7 @@ export const styles = css`
 			scale(var(--label-scale));
 		background-color: var(--cosmoz-input-floating-label-bg, var(--bg));
 	}
-	:host([always-float-label])::slotted(*),
-	#input:not(:placeholder-shown)::slotted(*) {
-		transform: translateY(var(--label-translate-y));
-	}
+
 	:host([always-float-label]) input,
 	#input:not(:placeholder-shown) {
 		transform: translateY(var(--label-translate-y));

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -61,13 +61,21 @@ export const contour = () => html`
 			--cosmoz-input-label-translate-y: 10px;
 			--cosmoz-input-float-display: none;
 			--cosmoz-input-padding: 10px 8px;
+			--cosmoz-input-slot-padding: 4px;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input'}></cosmoz-input>
 	<cosmoz-input
-		always-float-label
-		.label=${'This label always floats'}
-	></cosmoz-input>
+		.label=${'I want this input to have the suffix match the same placing!'}
+		type="number"
+		><span slot="suffix">${'suffix'}</span></cosmoz-input
+	>
+	<cosmoz-input .label=${'Same thing of above, with the prefix!'}
+		><span slot="prefix">${'Prefix:'}</span></cosmoz-input
+	>
+	<cosmoz-input always-float-label .label=${'This label always floats'}
+		><span slot="prefix">${'Example:'}</span></cosmoz-input
+	>
 
 	<cosmoz-input
 		invalid

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -61,7 +61,9 @@ export const contour = () => html`
 			--cosmoz-input-label-translate-y: 10px;
 			--cosmoz-input-float-display: none;
 			--cosmoz-input-padding: 10px 8px;
-			--cosmoz-input-slot-padding: 4px;
+		}
+		span {
+			margin: 0 4px;
 		}
 	</style>
 	<cosmoz-input .label=${'Insert a text input'}></cosmoz-input>


### PR DESCRIPTION
Fix in [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - the placing of suffix, prefix and other slotted components in cosmoz-input needs to be aligned to the one of the label.


https://github.com/Neovici/cosmoz-input/assets/122988480/969440d9-db20-4f4b-89f4-fef1a70f87f1

