### PR TITLE
fix: make shadowRoot input focusable

### DIFF
--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -3,6 +3,7 @@ import { live } from 'lit-html/directives/live.js';
 import { ref } from 'lit-html/directives/ref.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { component } from '@pionjs/pion';
+import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
 
 import { BaseInput, useInput } from './use-input';
 import { useAllowedPattern } from './use-allowed-pattern';
@@ -42,6 +43,15 @@ export const Input = (host: CosmozInput) => {
 		} = host,
 		{ onChange, onFocus, onInput, onRef } = useInput(host);
 	const onBeforeInput = useAllowedPattern(allowedPattern);
+
+	useImperativeApi(
+		{
+			focus: () =>
+				(host.shadowRoot?.querySelector('#input') as HTMLInputElement)?.focus(),
+		},
+		[],
+	);
+
 	return render(
 		html`
 			<input


### PR DESCRIPTION
Make input in host shadowRoot focusable

Reference: acceptance test (for using enter key two go to next input in form) failed on [PR#6963](https://github.com/Neovici/cosmoz-frontend/pull/6963) when changing native input to cosmoz-input

[AB#8222](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/8222/)