### PR TITLE
feat(required-input): required input needs specific ui

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -10,11 +10,12 @@ export interface Render {
 	label?: string;
 	invalid?: boolean;
 	errorMessage?: string;
+	required?: boolean;
 }
 
 export const render = <T>(
 		control: T,
-		{ label, invalid, errorMessage }: Render
+		{ label, invalid, errorMessage, required }: Render
 	) => html`
 		<style>
 			${styles}
@@ -28,6 +29,13 @@ export const render = <T>(
 				${when(
 					label,
 					() => html`<label for="input" part="label">${label}</label>`
+				)}
+				${when(
+					label && required,
+					() =>
+						html`<label for="input" part="label"
+							>${label + ' *'}
+						</label>`
 				)}
 			</div>
 			<slot name="suffix"></slot>
@@ -44,6 +52,7 @@ export const render = <T>(
 		'disabled',
 		'maxlength',
 		'invalid',
+		'required',
 		'no-label-float',
 		'always-float-label',
 	];

--- a/src/render.ts
+++ b/src/render.ts
@@ -28,14 +28,9 @@ export const render = <T>(
 				${control}
 				${when(
 					label,
-					() => html`<label for="input" part="label">${label}</label>`
-				)}
-				${when(
-					label && required,
-					() =>
-						html`<label for="input" part="label"
-							>${label + ' *'}
-						</label>`
+					required
+						? () => html`<label for="input" part="label">${label} *</label>`
+						: () => html`<label for="input" part="label">${label}</label>`
 				)}
 			</div>
 			<slot name="suffix"></slot>

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -49,6 +49,11 @@ export const color = () => html`
 	<cosmoz-input no-label-float type="color" .value=${'#ff0000'}></cosmoz-input>
 `;
 
+export const required = () => html`
+	${style}
+	<cosmoz-input required .label=${'This input is required'}></cosmoz-input>
+`;
+
 export const contour = () => html`
 	${style}
 	<style>


### PR DESCRIPTION
feature [AB#14937](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/14937) - required inputs are rn shown in red (according to the "invalid" input formatting), which becomes cumbersome and "in the user's face" whence there should be a long series of required inputs in a form. This change provides a dedicated rendering for the required inputs, closer to the techniques used by similar UIs in other contexts.