### PR TITLE
feat(attributes): accept attribute for file inputs

### DIFF
--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -40,6 +40,7 @@ export const Input = (host: CosmozInput) => {
 			max,
 			step,
 			maxlength,
+			accept,
 		} = host,
 		{ onChange, onFocus, onInput, onRef } = useInput(host);
 	const onBeforeInput = useAllowedPattern(allowedPattern);
@@ -49,7 +50,7 @@ export const Input = (host: CosmozInput) => {
 			focus: () =>
 				(host.shadowRoot?.querySelector('#input') as HTMLInputElement)?.focus(),
 		},
-		[],
+		[]
 	);
 
 	return render(
@@ -64,6 +65,7 @@ export const Input = (host: CosmozInput) => {
 				autocomplete=${ifDefined(autocomplete)}
 				placeholder=${getPlaceholder(host)}
 				?readonly=${readonly}
+				accept=${accept}
 				?aria-disabled=${disabled}
 				?disabled=${disabled}
 				.value=${live(value ?? '')}
@@ -78,11 +80,11 @@ export const Input = (host: CosmozInput) => {
 				step=${ifDefined(step)}
 			/>
 		`,
-		host,
+		host
 	);
 };
 
 customElements.define(
 	'cosmoz-input',
-	component<CosmozInput>(Input, { observedAttributes }),
+	component<CosmozInput>(Input, { observedAttributes })
 );

--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -65,7 +65,7 @@ export const Input = (host: CosmozInput) => {
 				autocomplete=${ifDefined(autocomplete)}
 				placeholder=${getPlaceholder(host)}
 				?readonly=${readonly}
-				.accept=${accept}
+				accept=${accept ?? '*/*'}
 				?aria-disabled=${disabled}
 				?disabled=${disabled}
 				.value=${live(value ?? '')}

--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -65,7 +65,7 @@ export const Input = (host: CosmozInput) => {
 				autocomplete=${ifDefined(autocomplete)}
 				placeholder=${getPlaceholder(host)}
 				?readonly=${readonly}
-				accept=${accept}
+				.accept=${accept}
 				?aria-disabled=${disabled}
 				?disabled=${disabled}
 				.value=${live(value ?? '')}

--- a/stories/cosmoz-input.stories.js
+++ b/stories/cosmoz-input.stories.js
@@ -86,3 +86,41 @@ export const contour = () => html`
 	></cosmoz-input>
 	<cosmoz-input disabled .label=${'This input is disabled!'}></cosmoz-input>
 `;
+
+export const file = () => html`
+	${style}
+	<style>
+		cosmoz-input {
+			--cosmoz-input-color: #aeacac;
+			--cosmoz-input-border-radius: 4px;
+			--cosmoz-input-wrap-padding: 12px;
+			--cosmoz-input-line-display: none;
+			--cosmoz-input-contour-size: 1px;
+			--cosmoz-input-label-translate-y: 10px;
+			--cosmoz-input-float-display: none;
+			--cosmoz-input-padding: 10px 8px;
+		}
+	</style>
+	<cosmoz-input .label=${'Upload any file'} type="file"></cosmoz-input>
+`;
+
+export const fileImage = () => html`
+	${style}
+	<style>
+		cosmoz-input {
+			--cosmoz-input-color: #aeacac;
+			--cosmoz-input-border-radius: 4px;
+			--cosmoz-input-wrap-padding: 12px;
+			--cosmoz-input-line-display: none;
+			--cosmoz-input-contour-size: 1px;
+			--cosmoz-input-label-translate-y: 10px;
+			--cosmoz-input-float-display: none;
+			--cosmoz-input-padding: 10px 8px;
+		}
+	</style>
+	<cosmoz-input
+		.label=${'Upload only JPG, JPEG, PNG or GIF files'}
+		type="file"
+		.accept=${'.jpg, .jpeg, .png, .gif'}
+	></cosmoz-input>
+`;


### PR DESCRIPTION
Quickfix - the cosmoz-input component should show the `accept` built-in property of the `input` native HTML, mainly for image file inputs.