### PR TITLE
fix: focus imperative api is defined twice

### DIFF
--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -3,7 +3,6 @@ import { live } from 'lit-html/directives/live.js';
 import { ref } from 'lit-html/directives/ref.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { component, sheet } from '@pionjs/pion';
-import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
 
 import { BaseInput, useInput } from './use-input';
 import { useAllowedPattern } from './use-allowed-pattern';
@@ -45,14 +44,6 @@ export const Input = (host: CosmozInput) => {
 		} = host,
 		{ onChange, onFocus, onInput, onRef } = useInput(host);
 	const onBeforeInput = useAllowedPattern(allowedPattern);
-
-	useImperativeApi(
-		{
-			focus: () =>
-				(host.shadowRoot?.querySelector('#input') as HTMLInputElement)?.focus(),
-		},
-		[],
-	);
 
 	return render(
 		html`

--- a/src/use-input.ts
+++ b/src/use-input.ts
@@ -14,22 +14,22 @@ export const useInput = <T extends BaseInput>(host: T) => {
 	const inputRef = useRef<Input | undefined>(undefined);
 	const onRef = useCallback(
 		(el?: Element) => (inputRef.current = el as Input),
-		[]
+		[],
 	);
 	const root = host.shadowRoot as ShadowRoot,
 		onChange = useCallback(
 			(e: Event) =>
 				host.dispatchEvent(new Event(e.type, { bubbles: e.bubbles })),
-			[]
+			[],
 		),
 		onInput = useCallback(
 			(e: InputEvent) =>
 				notifyProperty(host, 'value', (e.target as HTMLInputElement).value),
-			[]
+			[],
 		),
 		onFocus = useCallback(
 			(e: FocusEvent) => notifyProperty(host, 'focused', e.type === 'focus'),
-			[]
+			[],
 		),
 		focus = useCallback(() => inputRef.current?.focus(), []),
 		validate = useCallback(() => {


### PR DESCRIPTION
Noticed that the focus imperative API is created twice, once here and once in `useInput` (which already existed prior to this change). Code was added in https://github.com/Neovici/cosmoz-input/pull/85 and it mentions a failure in acceptance tests, but I fail to see how this change had anything to do with the failure getting resolved.

https://github.com/Neovici/cosmoz-input/blob/0bc98ad4d4bb2c624908c65ac8af59c69bf3faa5/src/use-input.ts#L34-L41

Even if it had an influence, we should not define it in two different places.