### PR TITLE
fix: use attribute bindings for error-message, hint and fix tooltip

### DIFF
--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -14,6 +14,7 @@ const observedAttributes = [
 	'type',
 	'variant',
 	'hint',
+	'error-message',
 	'compact',
 	'required',
 	'pattern',

--- a/src/cosmoz-textarea.ts
+++ b/src/cosmoz-textarea.ts
@@ -9,7 +9,15 @@ import { styles } from './styles';
 import { useAutoHeight } from './use-auto-height';
 import { BaseInput, useInput } from './use-input';
 
-const observedAttributes = ['rows', 'placeholder', ...attributes];
+const observedAttributes = [
+	'rows',
+	'placeholder',
+	'label',
+	'hint',
+	'error-message',
+	'required',
+	...attributes,
+];
 
 type CosmozInput = HTMLElement &
 	ObjectFromList<typeof observedAttributes> &

--- a/src/cosmoz-toggle.ts
+++ b/src/cosmoz-toggle.ts
@@ -108,6 +108,6 @@ customElements.define(
 	'cosmoz-toggle',
 	component(CosmozToggle, {
 		styleSheets: [style, toggleStyles],
-		observedAttributes: ['disabled'],
+		observedAttributes: ['label', 'disabled', 'error'],
 	}),
 );

--- a/src/render.ts
+++ b/src/render.ts
@@ -37,11 +37,11 @@ export const render = <T>(
 			</div>
 			<!-- compact: tooltip always visible, red icon when invalid -->
 			${when(
-				invalid,
+				compact && invalid && errorMessage,
 				() =>
 					html`<cosmoz-tooltip
 						placement="top"
-						description=${invalid ? errorMessage : label}
+						description=${errorMessage}
 						delay="300"
 					>
 						${infoCircleIcon({ width: '16px', height: '16px' })}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -49,7 +49,7 @@ export const styles = css`
 	}
 
 	.wrap:has(#input:focus) {
-		box-shadow: 0 0 0 2px var(--cz-color-border-brand);
+		box-shadow: var(--cz-focus-ring);
 	}
 
 	:host([invalid]) .wrap {
@@ -57,7 +57,7 @@ export const styles = css`
 	}
 
 	:host([invalid]) .wrap:has(#input:focus) {
-		box-shadow: 0 0 0 2px var(--cz-color-border-error);
+		box-shadow: var(--cz-focus-ring-error);
 	}
 
 	.control {

--- a/stories/cosmoz-input.stories.ts
+++ b/stories/cosmoz-input.stories.ts
@@ -82,8 +82,8 @@ const renderInput = (args: Record<string, unknown>) => html`
 		.label=${args.label || ''}
 		placeholder=${args.placeholder || ''}
 		.value=${args.value || ''}
-		.hint=${args.hint || ''}
-		.errorMessage=${args.errorMessage || ''}
+		hint=${args.hint || ''}
+		error-message=${args.errorMessage || ''}
 		type=${args.type || 'text'}
 		variant=${args.variant || ''}
 		?compact=${args.compact}
@@ -131,7 +131,7 @@ export const Default: Story = {
 					<cosmoz-input
 						.label=${'Email'}
 						placeholder=${'olivia@untitledui.com'}
-						.hint=${'This is a hint text to help user.'}
+						hint=${'This is a hint text to help user.'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -139,7 +139,7 @@ export const Default: Story = {
 					<cosmoz-input
 						.label=${'Email'}
 						placeholder=${'olivia@untitledui.com'}
-						.hint=${'This is a hint text to help user.'}
+						hint=${'This is a hint text to help user.'}
 						required
 					></cosmoz-input>
 				</div>
@@ -148,10 +148,10 @@ export const Default: Story = {
 					<cosmoz-input
 						.label=${'Email'}
 						.value=${'bad'}
-						.hint=${'This is a hint text to help user.'}
+						hint=${'This is a hint text to help user.'}
 						invalid
 						required
-						.errorMessage=${'This is an error message.'}
+						error-message=${'This is an error message.'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -214,7 +214,7 @@ export const Inline: Story = {
 						.value=${'not-an-email'}
 						variant="inline"
 						invalid
-						.errorMessage=${'Please enter a valid email'}
+						error-message=${'Please enter a valid email'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -320,7 +320,7 @@ export const Compact: Story = {
 						.label=${'Email'}
 						.value=${'bad value'}
 						invalid
-						.errorMessage=${'Invalid value'}
+						error-message=${'Invalid value'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -340,7 +340,7 @@ export const Compact: Story = {
 						.label=${'Filter'}
 						.value=${'bad'}
 						invalid
-						.errorMessage=${'Cell compact error'}
+						error-message=${'Cell compact error'}
 					></cosmoz-input>
 				</div>
 			</div>
@@ -364,11 +364,14 @@ export const LiveValidation: Story = {
 		const onInput = (e: InputEvent) => {
 			const el = e.target as HTMLElement & {
 				value: string;
-				errorMessage: string;
 			};
 			const valid = !el.value || emailRegex.test(el.value);
 			el.toggleAttribute('invalid', !valid);
-			el.errorMessage = valid ? '' : 'Please enter a valid email';
+			if (valid) {
+				el.removeAttribute('error-message');
+			} else {
+				el.setAttribute('error-message', 'Please enter a valid email');
+			}
 		};
 		return html`
 			<div class="story-stack">
@@ -378,7 +381,7 @@ export const LiveValidation: Story = {
 						<div class="story-label">Default</div>
 						<cosmoz-input
 							.label=${'Email'}
-							.hint=${'Type an invalid email'}
+							hint=${'Type an invalid email'}
 							placeholder=${'olivia@untitledui.com'}
 							required
 							@input=${onInput}
@@ -459,7 +462,7 @@ export const PrefixAndSuffix: Story = {
 							.label=${'Email'}
 							.value=${'bad'}
 							invalid
-							.errorMessage=${'Invalid email'}
+							error-message=${'Invalid email'}
 						>
 							${prefixIcon} ${suffixIcon}
 						</cosmoz-input>

--- a/stories/cosmoz-textarea.stories.ts
+++ b/stories/cosmoz-textarea.stories.ts
@@ -14,7 +14,11 @@ type Story = StoryObj;
 
 export const Basic: Story = {
 	render: () => html`
-		<cosmoz-textarea .label=${'Choose color'} .value=${'Red'}></cosmoz-textarea>
+		<cosmoz-textarea
+			.label=${'Choose color'}
+			.value=${'Red'}
+			hint=${'Hint text'}
+		></cosmoz-textarea>
 	`,
 	play: async ({ canvas, step }) => {
 		await step('Renders textarea element', async () => {
@@ -30,7 +34,7 @@ export const ErrorStory: Story = {
 			invalid
 			.label=${'Choose color'}
 			.value=${'Red\nGreen\nBlue'}
-			.errorMessage=${'Something is wrong!'}
+			error-message=${'Something is wrong!'}
 			.maxRows=${2}
 		></cosmoz-textarea>
 	`,


### PR DESCRIPTION
- Add error-message to cosmoz-input observedAttributes
- Add label, hint, error-message, required to cosmoz-textarea observedAttributes
- Add label, error to cosmoz-toggle observedAttributes
- Use attribute bindings (error-message=, hint=) instead of property bindings
  (.errorMessage=, .hint=) in stories
- Fix tooltip rendering to only show in compact mode (compact && invalid && errorMessage)
- Use CSS custom properties for focus ring styles