### PR TITLE
feat: add default max to date type

### DIFF
--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -8,7 +8,7 @@ import { attributes, ObjectFromList, Render, render } from './render';
 import { styles } from './styles';
 import { useAllowedPattern } from './use-allowed-pattern';
 import { BaseInput, useInput } from './use-input';
-import { getPlaceholder } from './util';
+import { defaultMax, getPlaceholder } from './util';
 
 const observedAttributes = [
 	'type',
@@ -67,7 +67,7 @@ export const Input = (host: CosmozInput) => {
 				@focus=${onFocus}
 				@blur=${onFocus}
 				min=${ifDefined(min)}
-				max=${ifDefined(max)}
+				max=${ifDefined(defaultMax(type, max))}
 				step=${ifDefined(step)}
 			/>
 		`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,4 +5,7 @@ interface Props {
 }
 export const getPlaceholder = ({ placeholder, noLabelFloat, label }: Props) => {
 	return (noLabelFloat ? label : undefined) || placeholder || ' ';
-}
+};
+
+export const defaultMax = (type: string, max?: string) =>
+	max ?? (type === 'date' ? '9999-12-31' : undefined);

--- a/stories/cosmoz-input.stories.ts
+++ b/stories/cosmoz-input.stories.ts
@@ -100,6 +100,13 @@ export const NoSpinner: Story = {
 	`,
 };
 
+export const Date: Story = {
+	render: () => html`
+		${style}
+		<cosmoz-input no-label-float type="date"></cosmoz-input>
+	`,
+};
+
 export const Contour: Story = {
 	render: () => html`
 		${style}


### PR DESCRIPTION
Updates cosmoz-input to use `9999-12-31` as the default max value so date input works better and automatically switches to the month field after 4 digits are entered in the year field.