### PR TITLE
feat: position hint and error absolutely to prevent autocomplete dropdown offset

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Use in HTML:
 <cosmoz-input label="Email" required hint="This field is required"></cosmoz-input>
 
 <!-- Invalid with error -->
-<cosmoz-input label="Email" value="bad" invalid error-message="Please enter a valid email"></cosmoz-input>
+<cosmoz-input label="Email" value="bad" invalid .errorMessage=${"Please enter a valid email"}></cosmoz-input>
 
 <!-- Inline variant -->
 <cosmoz-input label="Email" variant="inline"></cosmoz-input>
@@ -46,28 +46,35 @@ Use in HTML:
 
 ## Attributes
 
-| Attribute         | Type      | Default  | Description                                              |
-| ----------------- | --------- | -------- | -------------------------------------------------------- |
-| `label`           | `string`  | —        | Label text displayed above the input                     |
-| `placeholder`     | `string`  | `' '`    | Placeholder text                                         |
-| `value`           | `string`  | —        | Input value                                              |
-| `type`            | `string`  | `'text'` | Native input type (`text`, `number`, `color`, etc.)      |
-| `variant`         | `string`  | —        | Visual variant: `inline`, `cell`                         |
-| `compact`         | `boolean` | `false`  | Hides label/hint/error text; shows tooltip icon instead  |
-| `required`        | `boolean` | `false`  | Marks field as required, shows `*` on label              |
-| `invalid`         | `boolean` | `false`  | Toggles error state (red border, error message)          |
-| `error-message`   | `string`  | —        | Error text shown below input (or in tooltip when compact)|
-| `hint`            | `string`  | —        | Helper text below input (hidden when invalid)            |
-| `disabled`        | `boolean` | `false`  | Disables input, reduces opacity, `not-allowed` cursor    |
-| `readonly`        | `boolean` | `false`  | Makes input read-only                                    |
-| `autosize`        | `boolean` | `false`  | Input width adjusts to content length                    |
-| `no-spinner`      | `boolean` | `false`  | Hides number input spinner                               |
-| `autocomplete`    | `string`  | —        | Native autocomplete attribute                            |
-| `maxlength`       | `string`  | —        | Maximum character length                                 |
-| `min` / `max`     | `string`  | —        | Number input min/max constraints                         |
-| `step`            | `string`  | —        | Number input step value                                  |
-| `pattern`         | `string`  | —        | Regex validation pattern                                 |
-| `allowed-pattern` | `string`  | —        | Restricts input to matching characters                   |
+| Attribute         | Type      | Default  | Description                                             |
+| ----------------- | --------- | -------- | ------------------------------------------------------- |
+| `label`           | `string`  | —        | Label text displayed above the input                    |
+| `placeholder`     | `string`  | `' '`    | Placeholder text                                        |
+| `type`            | `string`  | `'text'` | Native input type (`text`, `number`, `color`, etc.)     |
+| `variant`         | `string`  | —        | Visual variant: `inline`, `cell`                        |
+| `compact`         | `boolean` | `false`  | Hides label/hint/error text; shows tooltip icon instead |
+| `required`        | `boolean` | `false`  | Marks field as required, shows `*` on label             |
+| `invalid`         | `boolean` | `false`  | Toggles error state (red border, error message)         |
+| `hint`            | `string`  | —        | Helper text below input (hidden when invalid)           |
+| `disabled`        | `boolean` | `false`  | Disables input, reduces opacity, `not-allowed` cursor   |
+| `readonly`        | `boolean` | `false`  | Makes input read-only                                   |
+| `autosize`        | `boolean` | `false`  | Input width adjusts to content length                   |
+| `no-spinner`      | `boolean` | `false`  | Hides number input spinner                              |
+| `autocomplete`    | `string`  | —        | Native autocomplete attribute                           |
+| `maxlength`       | `string`  | —        | Maximum character length                                |
+| `min` / `max`     | `string`  | —        | Number input min/max constraints                        |
+| `step`            | `string`  | —        | Number input step value                                 |
+| `pattern`         | `string`  | —        | Regex validation pattern                                |
+| `allowed-pattern` | `string`  | —        | Restricts input to matching characters                  |
+
+## Properties
+
+These are set via JavaScript property binding (`.prop=${value}`) and are **not** reflected as HTML attributes.
+
+| Property       | Type     | Default | Description                                                                              |
+| -------------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| `value`        | `string` | —       | Input value                                                                              |
+| `errorMessage` | `string` | —       | Error text shown below input (or in tooltip when compact). Use with `invalid` attribute. |
 
 ## Variants
 
@@ -76,7 +83,10 @@ Use in HTML:
 Standard bordered input with label above, hint/error text below, and a tooltip icon.
 
 ```html
-<cosmoz-input label="Email" hint="We will never share your email"></cosmoz-input>
+<cosmoz-input
+	label="Email"
+	hint="We will never share your email"
+></cosmoz-input>
 ```
 
 ### Inline (`variant="inline"`)
@@ -131,10 +141,10 @@ const isValid = input.validate(); // returns boolean, toggles invalid attribute
 
 ```javascript
 const onInput = (e) => {
-  const el = e.target;
-  const valid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(el.value);
-  el.toggleAttribute('invalid', !valid);
-  el.errorMessage = valid ? '' : 'Please enter a valid email';
+	const el = e.target;
+	const valid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(el.value);
+	el.toggleAttribute('invalid', !valid);
+	el.errorMessage = valid ? '' : 'Please enter a valid email';
 };
 ```
 
@@ -144,15 +154,15 @@ const onInput = (e) => {
 
 ## Slots
 
-| Slot      | Description                          |
-| --------- | ------------------------------------ |
-| `prefix`  | Content before the input (e.g. icon) |
-| `suffix`  | Content after the input (e.g. icon)  |
+| Slot     | Description                          |
+| -------- | ------------------------------------ |
+| `prefix` | Content before the input (e.g. icon) |
+| `suffix` | Content after the input (e.g. icon)  |
 
 ```html
 <cosmoz-input label="Email">
-  <svg slot="prefix" ...></svg>
-  <svg slot="suffix" ...></svg>
+	<svg slot="prefix" ...></svg>
+	<svg slot="suffix" ...></svg>
 </cosmoz-input>
 ```
 
@@ -169,13 +179,13 @@ const onInput = (e) => {
 
 ## State-driven rendering
 
-| Condition                              | Renders                                      |
-| -------------------------------------- | -------------------------------------------- |
-| `!compact && label`                    | Label (with `*` if `required`)               |
-| `compact` (valid)                      | Tooltip with help icon, shows `label`        |
-| `compact` (invalid)                    | Tooltip with info icon (red), shows `errorMessage` |
-| `!compact && hint && !invalid`         | Hint text below input                        |
-| `!compact && invalid && errorMessage`  | Error text below input (replaces hint)       |
+| Condition                             | Renders                                            |
+| ------------------------------------- | -------------------------------------------------- |
+| `!compact && label`                   | Label (with `*` if `required`)                     |
+| `compact` (valid)                     | Tooltip with help icon, shows `label`              |
+| `compact` (invalid)                   | Tooltip with info icon (red), shows `errorMessage` |
+| `!compact && hint && !invalid`        | Hint text below input                              |
+| `!compact && invalid && errorMessage` | Error text below input (replaces hint)             |
 
 ## Development
 

--- a/src/cosmoz-input.ts
+++ b/src/cosmoz-input.ts
@@ -14,7 +14,6 @@ const observedAttributes = [
 	'type',
 	'variant',
 	'hint',
-	'error-message',
 	'compact',
 	'required',
 	'pattern',

--- a/src/cosmoz-textarea.ts
+++ b/src/cosmoz-textarea.ts
@@ -14,7 +14,6 @@ const observedAttributes = [
 	'placeholder',
 	'label',
 	'hint',
-	'error-message',
 	'required',
 	...attributes,
 ];

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -11,6 +11,7 @@ export const styles = css`
 		font-size: var(--cz-text-base);
 		line-height: var(--cz-text-base-line-height);
 		font-family: var(--cz-font-body);
+		margin-bottom: calc(var(--cz-spacing) * 6);
 	}
 
 	:host(:focus-within) {
@@ -105,10 +106,14 @@ export const styles = css`
 	.hint {
 		font-size: var(--cz-text-xs);
 		color: var(--cz-color-text-tertiary);
+		position: absolute;
+		bottom: calc(var(--cz-spacing) * -6);
 	}
 
 	.error {
 		font-size: var(--cz-text-xs);
+		position: absolute;
+		bottom: calc(var(--cz-spacing) * -6);
 	}
 
 	/* === Tooltip (fluid error indicator) === */

--- a/stories/cosmoz-input.stories.ts
+++ b/stories/cosmoz-input.stories.ts
@@ -83,7 +83,7 @@ const renderInput = (args: Record<string, unknown>) => html`
 		placeholder=${args.placeholder || ''}
 		.value=${args.value || ''}
 		hint=${args.hint || ''}
-		error-message=${args.errorMessage || ''}
+		.errorMessage=${args.errorMessage || ''}
 		type=${args.type || 'text'}
 		variant=${args.variant || ''}
 		?compact=${args.compact}
@@ -151,7 +151,7 @@ export const Default: Story = {
 						hint=${'This is a hint text to help user.'}
 						invalid
 						required
-						error-message=${'This is an error message.'}
+						.errorMessage=${'This is an error message.'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -214,7 +214,7 @@ export const Inline: Story = {
 						.value=${'not-an-email'}
 						variant="inline"
 						invalid
-						error-message=${'Please enter a valid email'}
+						.errorMessage=${'Please enter a valid email'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -264,6 +264,8 @@ export const Cell: Story = {
 					<div class="story-label">Invalid</div>
 					<cosmoz-input
 						variant="cell"
+						required
+						placeholder=${'Required...'}
 						.value=${'bad value'}
 						invalid
 					></cosmoz-input>
@@ -320,7 +322,7 @@ export const Compact: Story = {
 						.label=${'Email'}
 						.value=${'bad value'}
 						invalid
-						error-message=${'Invalid value'}
+						.errorMessage=${'Invalid value'}
 					></cosmoz-input>
 				</div>
 				<div>
@@ -340,7 +342,7 @@ export const Compact: Story = {
 						.label=${'Filter'}
 						.value=${'bad'}
 						invalid
-						error-message=${'Cell compact error'}
+						.errorMessage=${'Cell compact error'}
 					></cosmoz-input>
 				</div>
 			</div>
@@ -364,13 +366,14 @@ export const LiveValidation: Story = {
 		const onInput = (e: InputEvent) => {
 			const el = e.target as HTMLElement & {
 				value: string;
+				errorMessage?: string;
 			};
 			const valid = !el.value || emailRegex.test(el.value);
 			el.toggleAttribute('invalid', !valid);
 			if (valid) {
-				el.removeAttribute('error-message');
+				el.errorMessage = undefined;
 			} else {
-				el.setAttribute('error-message', 'Please enter a valid email');
+				el.errorMessage = 'Please enter a valid email';
 			}
 		};
 		return html`
@@ -462,7 +465,7 @@ export const PrefixAndSuffix: Story = {
 							.label=${'Email'}
 							.value=${'bad'}
 							invalid
-							error-message=${'Invalid email'}
+							.errorMessage=${'Invalid email'}
 						>
 							${prefixIcon} ${suffixIcon}
 						</cosmoz-input>

--- a/stories/cosmoz-textarea.stories.ts
+++ b/stories/cosmoz-textarea.stories.ts
@@ -34,7 +34,7 @@ export const ErrorStory: Story = {
 			invalid
 			.label=${'Choose color'}
 			.value=${'Red\nGreen\nBlue'}
-			error-message=${'Something is wrong!'}
+			.errorMessage=${'Something is wrong!'}
 			.maxRows=${2}
 		></cosmoz-textarea>
 	`,


### PR DESCRIPTION
- Make hint/error spans position: absolute so they don't affect layout flow
- Add margin-bottom on host to reserve visual space
- Revert errorMessage from attribute back to property-only API (attribute was added to allow CSS targeting, but caused dropdown offset issues in some use cases of `cosmoz-autocomplete`)
- Update docs to distinguish attributes from properties

[FE-677](https://linear.app/neovici/issue/FE-677/fix-error-and-hint-issue)