### PR TITLE
feat: adapt cell variant for table layout

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -142,6 +142,10 @@ export const styles = css`
 	}
 
 	/* === Variant: inline === */
+	:host([variant='inline']) {
+		margin-bottom: 0;
+	}
+
 	:host([variant='inline']) .wrap {
 		margin-top: calc(var(--cz-spacing) * 2.5);
 	}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -202,24 +202,49 @@ export const styles = css`
 
 	/* === Variant: cell === */
 
-	:host([variant='cell']) .wrap {
+	:host([variant='cell']) {
+		margin-bottom: 0;
+		font-size: var(--cz-text-sm);
+		line-height: var(--cz-text-sm-line-height);
+	}
+
+	:host([variant='cell']) .wrap:has(#input) {
 		border: 0.5px solid var(--cz-color-bg-quaternary);
 		border-radius: 0;
 		box-shadow: none;
 	}
-	:host([variant='cell'][invalid]) .wrap {
-		border-color: var(--cz-color-border-error);
-	}
-	:host([variant='cell'][invalid]) .wrap:has(#input:focus) {
-		background: var(--cz-color-bg-error);
-		border: 0.5px solid transparent;
-	}
+
 	:host([variant='cell']) .wrap:has(#input:focus) {
 		background: var(--cz-color-bg-quaternary);
 	}
 
+	:host([variant='cell'][invalid]) .wrap:has(#input) {
+		border-color: var(--cz-color-border-error);
+		box-shadow: none;
+	}
+
+	:host([variant='cell'][invalid]) .wrap:has(#input:focus) {
+		background: var(--cz-color-bg-error);
+		border: 0.5px solid transparent;
+	}
+
 	:host([variant='cell']) label {
 		display: none;
+	}
+
+	:host([variant='cell']) .error {
+		left: calc(var(--cz-spacing) * 3);
+		bottom: 50%;
+		transform: translateY(50%);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		max-width: calc(100% - calc(var(--cz-spacing) * 6));
+	}
+
+	:host([variant='cell']:focus-within) .error,
+	:host([variant='cell'][has-value]) .error {
+		visibility: hidden;
 	}
 
 	/* === No spinner === */

--- a/stories/cosmoz-input.stories.ts
+++ b/stories/cosmoz-input.stories.ts
@@ -271,6 +271,14 @@ export const Cell: Story = {
 					></cosmoz-input>
 				</div>
 				<div>
+					<div class="story-label">Invalid + error message</div>
+					<cosmoz-input
+						variant="cell"
+						invalid
+						.errorMessage=${'Invalid cell value '}
+					></cosmoz-input>
+				</div>
+				<div>
 					<div class="story-label">Disabled</div>
 					<cosmoz-input
 						variant="cell"


### PR DESCRIPTION
- Remove margin-bottom on cell variant host (no hint/error space needed)
- Use smaller font-size/line-height for cell context
- Increase selector specificity with :has(#input) to override base box-shadow
- Position error message inline within the cell (vertically centered)
- Hide error on focus or when input has value
- Add story for cell variant with error message
- Removed bottom space for inline variant