### PR TITLE
chore: bump playwright to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@neovici/cosmoz-input",
-	"version": "5.7.1",
+	"version": "5.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@neovici/cosmoz-input",
-			"version": "5.7.1",
+			"version": "5.8.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
 		"sinon": "^22.0.0",
 		"storybook": "^10.1.9",
 		"vitest": "^4.0.18"
+	},
+	"overrides": {
+		"playwright": "1.60.0"
 	}
 }


### PR DESCRIPTION
Pin resolved playwright version to 1.60.0 via npm overrides to avoid browser version mismatches.

Relates to FE-879