### PR TITLE
chore: bump playwright to 1.60.0 (strict)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@commitlint/config-conventional": "^21.0.1",
 				"@neovici/cfg": "^2.8.0",
 				"@neovici/testing": "^2.3.0",
-				"@playwright/test": "^1.58.1",
+				"@playwright/test": "1.60.0",
 				"@storybook/addon-docs": "^10.0.0",
 				"@storybook/addon-vitest": "^10.2.4",
 				"@storybook/web-components-vite": "^10.2.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@commitlint/config-conventional": "^21.0.1",
 		"@neovici/cfg": "^2.8.0",
 		"@neovici/testing": "^2.3.0",
-		"@playwright/test": "^1.58.1",
+		"@playwright/test": "1.60.0",
 		"@storybook/addon-docs": "^10.0.0",
 		"@storybook/addon-vitest": "^10.2.4",
 		"@storybook/web-components-vite": "^10.2.4",
@@ -84,7 +84,5 @@
 		"storybook": "^10.1.9",
 		"vitest": "^4.0.18"
 	},
-	"overrides": {
-		"playwright": "1.60.0"
-	}
+	"overrides": {}
 }


### PR DESCRIPTION
Strictly pin @playwright/test to 1.60.0 and remove the now-redundant playwright override.\n\nRelates to https://linear.app/neovici/issue/FE-879