### PR TITLE
fix: allow clicks to pass through inline label to input

### DIFF
--- a/.changeset/inline-label-pointer-events.md
+++ b/.changeset/inline-label-pointer-events.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-input': patch
+---
+
+Allow clicks to pass through the inline label to the input

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -185,6 +185,7 @@ export const styles = css`
 		top: 25%;
 		left: 0;
 		width: 100%;
+		pointer-events: none;
 		transform-origin: left;
 		transition:
 			transform 0.25s,


### PR DESCRIPTION
## What

The inline variant label in `cosmoz-input` is absolutely positioned over the input with `z-index: 1` and `width: 100%`, so it intercepts pointer events meant for the input. This forces Playwright tests to use `force: true` when clicking the input.

## Fix

Add `pointer-events: none` to the inline label so clicks pass through to the input. Verified locally: the acceptance test passes without `force: true` and the visual is unchanged (input background is transparent).

```css
:host([variant='inline']) label {
	position: absolute;
	top: 25%;
	left: 0;
	width: 100%;
	pointer-events: none;
	...
}
```

## Changeset

Added `.changeset/inline-label-pointer-events.md` (patch).

Refs FE-1062