### PR TITLE
fix: allow clicks to pass through the floating label to the input

### DIFF
--- a/.changeset/label-pointer-events.md
+++ b/.changeset/label-pointer-events.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-input': patch
+---
+
+Allow clicks to pass through the floating label to the input

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -120,6 +120,7 @@ export const styles = css`
 		top: 0;
 		left: 0;
 		width: var(--cosmoz-input-label-width, 100%);
+		pointer-events: none;
 		transition:
 			transform 0.25s,
 			width 0.25s;

--- a/stories/cosmoz-input.test.stories.ts
+++ b/stories/cosmoz-input.test.stories.ts
@@ -207,3 +207,27 @@ export const BlurPrevention: Story = {
 		);
 	},
 };
+
+export const LabelClickThrough: Story = {
+	render: () => html`
+		${style}
+		<cosmoz-input label="Label"></cosmoz-input>
+	`,
+	play: async ({ canvasElement, step }) => {
+		const el = canvasElement.querySelector('cosmoz-input')!;
+		const input = el.shadowRoot!.querySelector('#input')!;
+		const label = el.shadowRoot!.querySelector('label[for="input"]')!;
+
+		await step('label does not intercept pointer events', async () => {
+			expect(getComputedStyle(label).pointerEvents).toBe('none');
+
+			// a click on the label must reach the input (focus it)
+			label.dispatchEvent(
+				new MouseEvent('mousedown', { bubbles: true, composed: true }),
+			);
+			await waitFor(() => {
+				expect(el.shadowRoot!.activeElement).toBe(input);
+			});
+		});
+	},
+};


### PR DESCRIPTION
Refs FE-1120

## Problem
Filter inputs in omnitable (e.g. the Status autocomplete filter) can't be clicked without Playwright `force: true`. The floating label of `cosmoz-input`/`cosmoz-textarea` is absolutely positioned over the input with no `pointer-events: none`, so it intercepts pointer events meant for the input/textarea.

The `mousedown` handler in `use-input.ts` `preventDefault()`s and focuses manually when a click doesn't land on an `input`/`textarea`; the label takes that branch, so focus is set but native caret placement is suppressed.

## Fix
Add `pointer-events: none` to the floating `label` so clicks pass through to the input and follow the native path (focus + caret).

## Test
Added `LabelClickThrough` regression test asserting the label has `pointer-events: none` and that a mousedown on it still focuses the input.

Full suite: 29/29 passing.