### PR TITLE
fix: keep floating label clickable

### DIFF
--- a/.changeset/calm-labels-click.md
+++ b/.changeset/calm-labels-click.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-input': patch
+---
+
+Keep the floating label clickable: revert `pointer-events: none` and let label clicks reach the input natively (fixes caret placement when clicking the label).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@neovici/cosmoz-input",
-	"version": "5.8.0",
+	"version": "5.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@neovici/cosmoz-input",
-			"version": "5.8.0",
+			"version": "5.8.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^6.0.0",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -120,7 +120,6 @@ export const styles = css`
 		top: 0;
 		left: 0;
 		width: var(--cosmoz-input-label-width, 100%);
-		pointer-events: none;
 		transition:
 			transform 0.25s,
 			width 0.25s;

--- a/src/use-input.ts
+++ b/src/use-input.ts
@@ -43,7 +43,7 @@ export const useInput = <T extends BaseInput>(host: T) => {
 	useEffect(() => {
 		const onMouseDown = (e: Event) => {
 			const target = (e as MouseEvent).composedPath()[0] as Element;
-			if (target?.closest?.('input, textarea')) return;
+			if (target?.closest?.('input, textarea, label')) return;
 			e.preventDefault();
 			inputRef.current?.focus();
 		};

--- a/stories/cosmoz-input.test.stories.ts
+++ b/stories/cosmoz-input.test.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { expect, fn, waitFor } from 'storybook/test';
+import { expect, fn, userEvent, waitFor } from 'storybook/test';
 import '../src/cosmoz-input';
 import { style } from './style';
 
@@ -218,13 +218,12 @@ export const LabelClickThrough: Story = {
 		const input = el.shadowRoot!.querySelector('#input')!;
 		const label = el.shadowRoot!.querySelector('label[for="input"]')!;
 
-		await step('label does not intercept pointer events', async () => {
-			expect(getComputedStyle(label).pointerEvents).toBe('none');
+		await step('label is clickable and focuses the input', async () => {
+			// the label must not intercept pointer events
+			expect(getComputedStyle(label).pointerEvents).not.toBe('none');
 
-			// a click on the label must reach the input (focus it)
-			label.dispatchEvent(
-				new MouseEvent('mousedown', { bubbles: true, composed: true }),
-			);
+			// a real click on the label must focus the input
+			await userEvent.click(label);
 			await waitFor(() => {
 				expect(el.shadowRoot!.activeElement).toBe(input);
 			});


### PR DESCRIPTION
## Problem

cosmoz-input 5.8.1 added `pointer-events: none` to the floating label (#368) as a band-aid for a real bug: the `mousedown` handler in `use-input.ts` swallows label clicks.

The label is a real `<label for="input">` (shared by both `<input>` and `<textarea>`), so clicking it should natively focus the input and place the caret. The handler over-reaches and `preventDefault()`s on label clicks, killing native caret placement — so #368 made the label non-hittable instead.

This breaks Playwright tests that click labels (`…intercepts pointer events`) and is a UX regression: a user clicking the label text gets nothing.

## Fix

- Revert `pointer-events: none` on the label (keep it clickable).
- Add `label` to the `closest` check in the `mousedown` handler so label clicks return early and the browser natively focuses the input + places the caret. Covers both input and textarea (shared handler).

## Tests

- Updated `LabelClickThrough` story to assert the label is clickable and a real click focuses the input.
- `cosmoz-input` (10) and `cosmoz-textarea` (2) storybook tests pass; `tsc` clean.